### PR TITLE
add support for dead letter queue and queue naming

### DIFF
--- a/openq/openq.py
+++ b/openq/openq.py
@@ -20,9 +20,11 @@ class OpenQ:
     A Simple Python in-memory message Queue Service
     """
 
-    def __init__(self, visiblity_timeout=30):
+    def __init__(self, name, visibility_timeout=30, dlq=None):
+        self.name = name
         self.messages = deque()
-        self.visiblity_timeout = visiblity_timeout
+        self.visibility_timeout = visibility_timeout
+        self.dlq = dlq  # Dead-letter queue
         self.lock = threading.Lock()
 
     def enqueue(self, message_body):
@@ -37,12 +39,15 @@ class OpenQ:
     def dequeue(self):
         """
         Simulate dequeuing messages from the queue, making them invisible for a defined timeout
+        Also starts a timer on each message that will call _requeue after the visibility timeout expires.
         """
         with self.lock:
             if not self.messages:
                 return None
             message = self.messages.pop()
             message.received_at = int(time.time())
+            t = threading.Timer(self.visibility_timeout, self._requeue, [message])
+            t.start()
             return message
 
     def delete(self, message_id):
@@ -50,38 +55,49 @@ class OpenQ:
         Simulate consumers sending back acknowledgment of message processing
         """
         with self.lock:
-            # In a real scenario, you'd search by ID and remove the specific message
-            # For simplicity, we're assuming the consumer processes the last received message
-            if not self.messages or self.messages[-1].id != message_id:
-                raise VisiblityTimeOutExpired(
-                    "Message ID not found or already acknowledged."
-                )
+            if any(m.id == message_id for m in self.messages):
+                for message in self.messages:
+                    if message.id == message_id:
+                        if self._visibility_timeout_expired(message):
+                            raise VisiblityTimeOutExpired(
+                                "Visibility timeout expired; message requeued."
+                            )
+                        self.messages.remove(message)  # Remove message from queue
+                        print(f"Acknowledged Task ID: {message.id}")
+                        return
+        raise VisiblityTimeOutExpired("Message ID not found or already acknowledged.")
 
-            if self._visibility_timeout_expired(self.messages[-1]):
-                raise VisiblityTimeOutExpired(
-                    "Visibility timeout expired; message requeued."
-                )
-
-            # Delete the message (acknowledgement of successful processing)
-            self.messages.pop()
+    def _requeue(self, message):
+        """
+        Helper method to renqueue messages of they timeout
+        """
+        with self.lock:
+            if self._visibility_timeout_expired(message):
+                if self.dlq:
+                    print(f"Task ID: {message.id} moved to DLQ")
+                    # Move to DLQ
+                    self.dlq.enqueue(message.body)
+                else:
+                    # Requeue in the current queue
+                    self.messages.appendleft(message)
 
     def _visibility_timeout_expired(self, message):
         """
         Helper method to check visibility timeout
         """
         now = int(time.time())
-        expiry_time = message.received_at + message.visiblity_timeout
+        expiry_time = message.received_at + self.visibility_timeout
         return now >= expiry_time
 
 
-def producer(queue):
+def producer(queue, num_tasks):
     """
     Producing messages to queue
     """
-    for i in range(5):
+    for i in range(num_tasks):
         message_body = f"Task {i}"
         message_id = queue.enqueue(message_body)
-        print(f"Produced Task ID: {message_id}")
+        print(f"Produced to Queue: {queue.name} Task ID: {message_id}")
         time.sleep(1)
 
 
@@ -89,6 +105,7 @@ def consumer(queue):
     """
     Consumes message and listen to queue
     """
+    print("### CONSUMER ###")
     while True:
         message = queue.dequeue()
         if message:
@@ -97,20 +114,25 @@ def consumer(queue):
                 # Simulate processing time
                 time.sleep(2)
                 queue.delete(message.id)
-                print(f"Acknowledged Task ID: {message.id}")
             except VisiblityTimeOutExpired as e:
                 print(str(e))
         else:
-            print("Queue is empty, waiting for tasks...")
+            print(f"{queue.name} is empty, waiting for tasks...")
             time.sleep(1)
 
 
-# Create an instance of the queue with a short visibility timeout for demonstration
+## Queue Creation Junction ##
 
-openq = OpenQ(visiblity_timeout=10)
+# Create main queue and dead-letter queue
+dlq = OpenQ(name="dead-letter-queue", visibility_timeout=10)
+main_queue = OpenQ(name="main-queue", visibility_timeout=10, dlq=dlq)
 
-producer_thread = threading.Thread(target=producer, args=(openq,))
-consumer_thread = threading.Thread(target=consumer, args=(openq,))
+# Set number of tasks to be produced
+num_tasks = 5
+
+# Using threading to simulate concurrent producing and consuming processes
+producer_thread = threading.Thread(target=producer, args=(main_queue, num_tasks))
+consumer_thread = threading.Thread(target=consumer, args=(main_queue,))
 
 producer_thread.start()
 consumer_thread.start()


### PR DESCRIPTION
Changes made:

- Added name attribute to the OpenQ class to store the name of the queue.
- Added dlq attribute to hold an instance of another OpenQ object that acts as the DLQ.
- Modified the dequeue method to start a timer on each message that will call _requeue after the visibility timeout expires.
- Updated the _requeue method to transfer messages to DLQ if one exists, otherwise it'll put them back at the head of the queue.
- Removed the delete method's assumption that the last received message is the one to be deleted and added iteration through all messages.